### PR TITLE
Ajout script Umami suivi des visites

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,4 +39,6 @@
     <!-- WEBSITE ICON IN BROWSER -->
     <link rel="icon" type="image/png" href="{{ 'images/logos/logo-small-transparent.png' | relative_url }}">
 
+    <script async defer data-website-id="fe1159ae-637e-47dc-a9a5-47d9cdacf8c2" src="https://umami.mtg-france.org/umami.js"></script>
+
 </head>


### PR DESCRIPTION
Ajout d'un script de suivi des visites basé sur Umami (auto-hébergé)

Avant de valider la PR, il faut : 

- [x] Pointer le sous-domaine `umami.mtg-france.org` vers le serveur, en faisant un CNAME vers `caprover.pericia.fr`
- [x] Activer https (je le ferai dès que le domaine sera bon)

Une fois configuré, les stats seront visibles sur l'url suivante : 
https://umami.mtg-france.org/share/CsBrujCN/MTG%3AFrance

(C'est public, je peux le rendre privé avec login/mdp si nécessaire, mais je pense pas que ça soit vraiment utile)